### PR TITLE
Wait for transaction to commit before applying run_import_job

### DIFF
--- a/import_export_celery/models/importjob.py
+++ b/import_export_celery/models/importjob.py
@@ -20,7 +20,7 @@ from datetime import datetime
 from author.decorators import with_author
 
 from django.conf import settings
-from django.db import models
+from django.db import models, transaction
 from django.dispatch import receiver
 
 from django.db.models.signals import post_save
@@ -95,4 +95,4 @@ def importjob_post_save(sender, instance, **kwargs):
     if not instance.processing_initiated:
         instance.processing_initiated = datetime.now()
         instance.save()
-        run_import_job.delay(instance.pk, dry_run=True)
+        transaction.on_commit(lambda: run_import_job.delay(instance.pk, dry_run=True))


### PR DESCRIPTION
Solving #46 
Actually there is a better way to do this as stated here: https://stackoverflow.com/questions/45276828/handle-post-save-signal-in-celery