### PR TITLE
Add apps.py to avoid underscores in admin app label

### DIFF
--- a/import_export_celery/apps.py
+++ b/import_export_celery/apps.py
@@ -1,0 +1,7 @@
+from django.apps import AppConfig
+from django.utils.translation import gettext_lazy as _
+
+
+class ImportExportCeleryConfig(AppConfig):
+    name = 'import_export_celery'
+    verbose_name = _("Import Export Celery")


### PR DESCRIPTION
A simple change to avoid the app label appearing with underscores in admin.