### PR TITLE
Handle errors with no message_dict

### DIFF
--- a/import_export_celery/tasks.py
+++ b/import_export_celery/tasks.py
@@ -142,17 +142,24 @@ def _run_import_job(import_job, dry_run=True):
             cols = lambda row: "</td><td>".join(
                 [str(field) for field in row.values]
             )
-            cols_error = lambda row: "".join(
-                [
-                    "<mark>"
-                    + key
-                    + "</mark>"
-                    + "<br>"
-                    + row.error.message_dict[key][0]
-                    + "<br>"
-                    for key in row.error.message_dict.keys()
-                ]
-            )
+            
+            def cols_error(row):
+                if hasattr(row.error, 'message_dict'):
+                    return "".join(
+                        [
+                            "<mark>"
+                            + key
+                            + "</mark>"
+                            + "<br>"
+                            + row.error
+                            + row.error.message_dict[key][0]
+                            + "<br>"
+                            for key in row.error.message_dict.keys()
+                        ]
+                    )   
+                else:
+                    return str(row.error)
+                    
             summary += (
                 "<tr><td>row</td>"
                 + "<td>errors</td><td>"


### PR DESCRIPTION
Some ValidationErrors will not have a message_dict. Currently this code throws if this is the case. This will allow the error to be properly logged.