### PR TITLE
Manage custom storage class using django.core.files.storage.storages …

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -172,11 +172,15 @@ To exclude or disable file formats from the admin site, configure `IMPORT_EXPORT
 Customizing File Storage Backend
 --------------------------------
 
-Define a custom storage backend by adding the `IMPORT_EXPORT_CELERY_STORAGE` to your Django settings. For instance:
+Define a custom storage backend by adding the `IMPORT_EXPORT_CELERY_STORAGE` to your Django settings STORAGES definition. For instance:
 
     ::
 
-        IMPORT_EXPORT_CELERY_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
+        STORAGES = {
+            "IMPORT_EXPORT_CELERY_STORAGE": {
+                "BACKEND": "storages.backends.s3boto3.S3Boto3Storage",
+            },
+        }
 
 Customizing Task Time Limits
 ----------------------------

--- a/example/project/settings.py
+++ b/example/project/settings.py
@@ -89,6 +89,11 @@ DATABASES = {
     },
 }
 
+STORAGES = {
+    "IMPORT_EXPORT_CELERY_STORAGE": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+    },
+}
 
 # Password validation
 # https://docs.djangoproject.com/en/1.10/ref/settings/#auth-password-validators
@@ -135,7 +140,6 @@ IMPORT_EXPORT_CELERY_MODELS = {
 }
 
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
-IMPORT_EXPORT_CELERY_STORAGE = "django.core.files.storage.FileSystemStorage"
 
 # Default import time limits (in seconds)
 IMPORT_EXPORT_CELERY_IMPORT_SOFT_TIME_LIMIT = 300  # 5 minutes

--- a/import_export_celery/fields.py
+++ b/import_export_celery/fields.py
@@ -1,18 +1,27 @@
 from django.conf import settings
-from django.core.files.storage import get_storage_class, storages
 from django.db import models
 
 
 def lazy_initialize_storage_class():
     # If the user has specified a custom storage backend, use it.
-    if getattr(settings, "IMPORT_EXPORT_CELERY_STORAGE", None):
+    if settings.STORAGES.get("IMPORT_EXPORT_CELERY_STORAGE"):
         try:
-            storage_class = get_storage_class(settings.IMPORT_EXPORT_CELERY_STORAGE)
-            return storage_class()
-        except (ImportError, TypeError):
-            return storages[settings.IMPORT_EXPORT_CELERY_STORAGE]
-
-    return None
+            # From Django 4.2 and later
+            from django.core.files.storage import storages
+            from django.core.files.storage.handler import InvalidStorageError
+            try:
+                storage_class = storages['IMPORT_EXPORT_CELERY_STORAGE']
+            except InvalidStorageError:
+                from django.utils.module_loading import import_string
+                storage_class = settings.DEFAULT_FILE_STORAGE
+                storage_class = import_string(storage_class)()
+        except ImportError:
+            # Deprecated since Django 4.2, Removed in Django 5.1
+            from django.core.files.storage import get_storage_class
+            storage_class = get_storage_class(
+                settings.STORAGES.get("IMPORT_EXPORT_CELERY_STORAGE")["BACKEND"]
+            )()
+        return storage_class
 
 
 class ImportExportFileField(models.FileField):


### PR DESCRIPTION
…modules instead of deprecated method

In Django documentation we can see that get_storage_class is deprecated in Django 5.1 and later.

https://docs.djangoproject.com/en/5.0/ref/files/storage/#django.core.files.storage.get_storage_class

Recommendation of Django is to use storages instead of get_storage_class. This leads to specify this file storage backend in STORAGES config settings instead of a new config variable.

This commit allows also to keep using custom storage classe from older verions (4.2 and earlier) and prevents to crash when invalid storage class is provided, using the default one.

Solves https://github.com/auto-mat/django-import-export-celery/issues/115