### PR TITLE
add BackgroundJobExportMixin

### DIFF
--- a/example/winners/admin.py
+++ b/example/winners/admin.py
@@ -2,13 +2,15 @@
 from django.contrib import admin
 
 from import_export.admin import ImportExportMixin
+
+from import_export_celery.admin import BackgroundJobExportMixin
 from import_export_celery.admin_actions import create_export_job_action
 
 from . import models
 
-
 @admin.register(models.Winner)
-class WinnerAdmin(ImportExportMixin, admin.ModelAdmin):
+class WinnerAdmin(BackgroundJobExportMixin, ImportExportMixin, admin.ModelAdmin):
     list_display = ("name",)
 
     actions = (create_export_job_action,)
+    resource_classes = (models.WinnersResource,)

--- a/import_export_celery/admin.py
+++ b/import_export_celery/admin.py
@@ -1,11 +1,20 @@
 # Copyright (C) 2019 o.s. Auto*Mat
+import json
+import pickle
+from base64 import b64encode
+
+import django
 from django import forms
 from django.conf import settings
 from django.contrib import admin
 from django.core.cache import cache
+from django.shortcuts import redirect
 from django.utils.translation import gettext_lazy as _
+from import_export.admin import ExportMixin
+from import_export.forms import SelectableFieldsExportForm
 
 from . import admin_actions, models
+from .models import ExportJob
 
 
 class JobWithStatusMixin:
@@ -111,3 +120,45 @@ class ExportJobAdmin(JobWithStatusMixin, admin.ModelAdmin):
         return False
 
     actions = (admin_actions.run_export_job_action,)
+
+
+class BackgroundJobSelectableFieldsExportForm(SelectableFieldsExportForm):
+    background_job = forms.BooleanField(
+        required=False,
+        initial=False,
+        label="Run export in background, will export all fields",
+    )
+
+
+class BackgroundJobExportMixin(ExportMixin):
+    export_form_class = BackgroundJobSelectableFieldsExportForm
+
+    def _do_file_export(self, file_format, request, queryset, export_form=None):
+        if not export_form.cleaned_data.get("background_job"):
+            return super()._do_file_export(file_format, request, queryset, export_form=export_form)
+        base64_pickle_qs = b64encode(pickle.dumps(queryset.query)).decode("ascii")
+        export_class = self.choose_export_resource_class(export_form, request)
+        model_class = export_class.Meta.model
+        resource_classes = model_class.export_resource_classes()
+        resource = None
+        for resource_key, resource_choice in resource_classes.items():
+            _resource_label, resource_class = resource_choice
+            if resource_class == export_class:
+                resource = resource_key
+                break
+        job = ExportJob(
+            app_label=self.model._meta.app_label,
+            model=self.model._meta.model_name,
+            site_of_origin=request.scheme + "://" + request.get_host(),
+            queryset=json.dumps(
+                {
+                    "queryString": request.GET.urlencode(),
+                    "djangoVersion": django.get_version(),
+                    "query": base64_pickle_qs,
+                }
+            ),
+            resource=resource,
+            format=file_format.CONTENT_TYPE,
+        )
+        job.save()
+        return redirect(f"admin:{job._meta.app_label}_{job._meta.model_name}_change", job.id)


### PR DESCRIPTION
Fully functional concept of possible fix for #111. It saves the queryset from export page and use it when export performed later in a job.

I don't know better way to save/restore queryset between initial request and celery job, too many points in django where queryset can be dynamically modified.

In case of python or django upgrade, if serialized with pickle query breaks it can be  re-created from saved `queryString`.

Select/unselect fields to be exported are not supported, all fields will be exported in current implementation but this feature can be added.

`django-import-export` and `django-import-export-celery` select resources differently, some work needs to be done for unification and better integration of feature.

Trigger of `run_export_job.delay` needs to be updated and separated from creation and scheduling task execution to be able to create job without scheduling it automatically, to set non default values for `Site of origin:` and `Send me an email when this export job is complete` and than schedule job after that.

See also #130 